### PR TITLE
Make timeouts configurable on the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ c.xlsx('input.pdf', 'output.xlsx')
 
 ## Configuring a timeout
 
-If you are converting a large document, you may want to increase the timeout.
-The below example allows 60 seconds to connect to our server, and 1 hour to
-convert the document.
+If you are converting a large document (hundreds or thousands of pages),
+you may want to increase the timeout.
+
+Here is an example of the sort of error that might be encountered:
+
+```
+ReadTimeout: HTTPSConnectionPool(host='pdftables.com', port=443): Read timed out. (read timeout=300)
+```
+
+The below example allows 60 seconds to connect to our server, and 1 hour to convert the document:
 
 ```py
 import pdftables_api

--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ c.xlsx('input.pdf', 'output.xlsx')
 ## Test
 
     python -m unittest test.test_pdftables_api
+
+## Configuring a timeout
+
+If you are converting a large document, you may want to increase the timeout.
+The below example allows 60 seconds to connect to our server, and 1 hour to
+convert the document.
+
+```py
+import pdftables_api
+
+c = pdftables_api.Client('my-api-key', timeout=(60, 3600))
+c.xlsx('input.pdf', 'output.xlsx')
+```

--- a/pdftables_api/pdftables_api.py
+++ b/pdftables_api/pdftables_api.py
@@ -40,9 +40,10 @@ _EXT_FORMATS = {
 
 
 class Client(object):
-    def __init__(self, api_key, api_url=_API_URL):
+    def __init__(self, api_key, api_url=_API_URL, timeout=_DEFAULT_TIMEOUT):
         self.api_key = api_key
         self.api_url = api_url
+        self.timeout = timeout
 
     def xlsx(self, pdf_path, xlsx_path):
         """
@@ -94,7 +95,7 @@ class Client(object):
             raise APIException("Invalid API key")
 
         if 'timeout' not in requests_params:
-            requests_params.update({'timeout': _DEFAULT_TIMEOUT})
+            requests_params.update({'timeout': self.timeout})
 
         (_, out_format) = Client.ensure_format_ext(None, out_format)
         url = self.api_url


### PR DESCRIPTION
This adds a configuration parameter to the `Client` and documents it in
the README.md.