### PR TITLE
Update installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ Python library to interact with the
 
 ## Installation
 
-PIP:
+pip: (requires git installed)
 
     pip install git+https://github.com/pdftables/python-pdftables-api.git
 
+pip: (without git)
+
+    pip install https://github.com/pdftables/python-pdftables-api/archive/master.tar.gz
+    
 Locally:
 
     python setup.py install


### PR DESCRIPTION
User emailed us with Python error of pdftables_api couldn't be found.

Seems plausible to me that install might have failed due to no git 
installation (e.g. user is on Windows).

So, this updates the README to reflect that.