### PR TITLE
Update Travis to test supported Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: python
 python:
  - "2.7"
- - "3.4"
  - "3.5"
  - "3.6"
-# Hack for Python 3.7; remove when Travis correctly supports it.
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+ - "3.7"
+ - "3.8"
 script:
  - python setup.py test


### PR DESCRIPTION
3.4 is end-of-life.

Travis also supports 3.7 (and 3.8) without hacks, so remove that too.