### PR TITLE
Document supported Python versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Python library to interact with the
 [PDFTables.com](https://pdftables.com/api) API.
 
+Supported versions of Python are listed in [.travis.yml](.travis.yml).
+
 
 ## Installation
 


### PR DESCRIPTION
We support the versions that we test, therefore point to .travis.yml.