### PR TITLE
Change supported Python versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
* Drop Python 3.7 (end of life in June 2023).
* Add Python 3.11.